### PR TITLE
Avoid Collision with Walls | Change in coordinates

### DIFF
--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -29,8 +29,8 @@ def main( n):
         newbot+="\"" + str(botname) + "\""
         newbot+="""/>\n"""
         newbot+="""<arg name="init_pose" value="""
-        x = -12+0.5*i
-        y = -12+0.5*i
+        x = -10+0.5*i
+        y = -10+0.5*i
         newbot+="\"" + "-x " + str(x) + " -y " + str(y) + " -z 0" +"\"" + "/>\n"
         newbot+="</include>\n"
         newbot+="""</group>\n"""


### PR DESCRIPTION
The previous code had (-12 + 0.5_i, -12 + 0.5_i) as the coordinates which sometimes resulted in collisions of the some of the robots with the walls. Have shifted the spawn position by 2 units in both the horizontal and vertical axes.
